### PR TITLE
Supply a shim to replace imp.load_source on Python 3.12+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,24 @@
 import os
 from os.path import join as ospj
 import io
-import imp
+try:
+    # Already obsolete, deprecated, and undocumented by Python 3.11, this was
+    # removed in Python 3.12 along with the rest of the imp module.
+    from imp import load_source
+except ImportError:
+    # A shim to replace imp.load_source, very loosely inspired by
+    # https://github.com/cuthbertLab/music21/pull/1424.
+    from importlib.util import spec_from_file_location, module_from_spec
+
+    def load_source(name, path):
+        spec = spec_from_file_location(name, path)
+        if spec is not None and spec.loader is not None:
+            module = module_from_spec(spec)
+            if module is not None:
+                spec.loader.exec_module(module)
+                return module
+        raise FileNotFoundError('Could not load %r' % path)
+
 from setuptools import setup, find_packages
 
 _dir = os.path.abspath(os.path.dirname(__file__))
@@ -20,7 +37,7 @@ TESTS  = ospj(_dir, 'tests')
 # import pkginfo without importing 'fspath/__init__.py' which imports
 # third-party dependencies that need to be installed first (e.g. 'six').
 
-PKG = imp.load_source('__pkginfo__', ospj(SRC, '__pkginfo__.py'))
+PKG = load_source('__pkginfo__', ospj(SRC, '__pkginfo__.py'))
 
 def readFile(fname, m='rt', enc='utf-8', nl=None):
     with io.open(fname, mode=m, encoding=enc, newline=nl) as f:


### PR DESCRIPTION
This is not pretty, but it seems to provide an acceptable workaround for the time being.

I get a couple of test failures when I try this in a venv,

```
FAILED tests/test_FSPath.py::test_download - ZeroDivisionError: float division by zero
FAILED tests/test_FSPath.py::test_ZIP - AssertionError: assert False
```

but they seem to be irrelevant to this PR, and I get the same errors on Python 2.7 and 3.6 (I can’t test 3.5).