### PR TITLE
[fix] `imp` module is removed in Python 3.12 / replaced by importlib

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,3 @@
-# -*- coding: utf-8; mode: conf -*-
 # lint Python modules using external checkers.
 #
 # This is the main checker controlling the other ones and the reports
@@ -59,7 +58,11 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=bad-whitespace, duplicate-code
+disable=duplicate-code,
+        missing-function-docstring,
+        consider-using-f-string,
+	redundant-u-string-prefix,
+	useless-object-inheritance,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -105,17 +108,8 @@ max-nested-blocks=5
 
 [BASIC]
 
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,apply,input
-
-# Naming hint for argument names
-argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
 # Regular expression matching correct argument names
 argument-rgx=(([a-z][a-zA-Z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Naming hint for attribute names
-attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct attribute names
 attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*)|([A-Z0-9_]*))$
@@ -123,20 +117,11 @@ attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*)|([A-Z0-9_]*))$
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
 
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct constant names
 const-rgx=(([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
@@ -145,9 +130,6 @@ const-rgx=(([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
 docstring-min-length=-1
-
-# Naming hint for function names
-function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct function names
 function-rgx=(([a-z][a-zA-Z0-9_]{2,30})|(_[a-z0-9_]*))$
@@ -158,20 +140,11 @@ good-names=i,j,k,ex,Run,_,log,cfg,id
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no
 
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
-# Naming hint for method names
-method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
 # Regular expression matching correct method names
 method-rgx=(([a-z][a-zA-Z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct module names
 #module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -188,9 +161,6 @@ no-docstring-rgx=^_
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
 property-classes=abc.abstractproperty
-
-# Naming hint for variable names
-variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct variable names
 variable-rgx=(([a-z][a-zA-Z0-9_]{2,30})|(_[a-z0-9_]*)|([a-z]))$
@@ -216,12 +186,6 @@ max-line-length=120
 
 # Maximum number of lines in a module
 max-module-lines=2000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.No config file found, using default configuration
@@ -441,4 +405,4 @@ known-third-party=enchant
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/fspath/__init__.py
+++ b/fspath/__init__.py
@@ -29,4 +29,3 @@ from .os_env import OS_ENV
 from ._which import which
 
 from .progressbar import progressbar
-

--- a/fspath/_which.py
+++ b/fspath/_which.py
@@ -6,7 +6,7 @@ which - locate a command
 
 import sys
 import os
-import fspath
+import fspath  # pylint: disable=cyclic-import
 from .cli import CLI
 
 
@@ -25,7 +25,7 @@ def which(cmd, findall=True):
 
     """
     envpath = os.environ.get('PATH', None) or os.defpath
-    hits = list()
+    hits = []
     cmd  = fspath.FSPath(cmd)
 
     if sys.platform == 'win32':

--- a/fspath/cli.py
+++ b/fspath/cli.py
@@ -115,6 +115,7 @@ class CLI(object):
         """Add subcommand parser"""
 
         if self.cliSubParsers is None:
+            # pylint: disable=broad-exception-raised
             raise Exception("this command-line has no sub-commands!")
 
         subCmd = self.cliSubParsers.add_parser(
@@ -163,14 +164,14 @@ class CLI(object):
                     _exitCode = 0
                 else:
                     _exitCode = int(_retVal)
-            except Exception as exc: # pylint: disable=W0703
+            except Exception as exc: # pylint: disable=unused-variable, broad-exception-caught
                 pass
 
-        except CLIApplError as exc: # pylint: disable=W0703
+        except CLIApplError as exc: # pylint: disable=unused-variable
             _exitCode  = exc.exitCode
             self.ERR.write(u"ERROR (%s): %s\n" % (exc.exitCode, exc.message))
 
-        except Exception as exc: # pylint: disable=W0703
+        except Exception as exc: # pylint: disable=unused-variable, broad-exception-caught
             if cmd_args.debug:
                 raise
             _exitCode  = 42
@@ -212,7 +213,7 @@ class CLI(object):
         if '_ARGCOMPLETE' not in os.environ:
             return
         try:
-            import argcomplete  # pylint: disable=import-error
+            import argcomplete  # pylint: disable=import-error, import-outside-toplevel
         except ImportError:
             self.ERR.write("TAB-completion, python-argcomplete not installed.")
             sys.exit(1)
@@ -237,7 +238,7 @@ def CONSOLE(arround=5, frame=None):
 
     histfile = os.path.join(os.path.expanduser("~"), ".kernel-doc-history")
     try:
-        import readline, rlcompleter  # pylint: disable=W0612
+        import readline, rlcompleter  # pylint: disable=import-outside-toplevel
         readline.set_completer(rlcompleter.Completer(namespace=ns).complete)
         readline.parse_and_bind("tab: complete")
         readline.set_history_length(1000)
@@ -274,4 +275,3 @@ def DUMMY_CONSOLE(*_x, **_y):
 __builtins__["CONSOLE"] = DUMMY_CONSOLE
 if DEBUG:
     __builtins__["CONSOLE"] = CONSOLE
-

--- a/fspath/compat.py
+++ b/fspath/compat.py
@@ -23,4 +23,3 @@ else:
             for line in text.splitlines(True):
                 yield (prefix + line if predicate(line) else line)
         return ''.join(prefixed_lines())
-

--- a/fspath/console.py
+++ b/fspath/console.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# pylint: disable=invalid-name, bad-continuation
+# pylint: disable=invalid-name
 """
 Some *console* stuff
 """
@@ -65,7 +65,7 @@ def consoleDimensionsLinux():
 
 def consoleDimensionsWIN():
     u"""Returns count of (row, columns) from current console"""
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals, import-outside-toplevel
     from ctypes import windll, create_string_buffer
 
     # stdin handle is -10

--- a/fspath/debug.py
+++ b/fspath/debug.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; mode: python -*-
-# pylint: disable=invalid-name, logging-not-lazy
+# pylint: disable=invalid-name, logging-not-lazy, arguments-renamed
 
 """
 Small collection for debugging and introspection purpose.
@@ -219,7 +219,7 @@ class RemoteConsole(Console):
 class Pdb(pdb.Pdb):  # pylint: disable=R0904
 # ==============================================================================
 
-    # pylint: disable=no-self-use, missing-docstring
+    # pylint: disable=missing-docstring
     u"""Abstraction Layer for PDB"""
     def do_src(self, arg):
         if not arg:
@@ -245,8 +245,7 @@ class RemotePdb(Pdb): # pylint: disable=R0904
 # ==============================================================================
     u"""Simple remote PDB"""
 
-    # pylint: disable=no-self-use, missing-docstring
-    # pylint: disable=super-init-not-called
+    # pylint: disable=missing-docstring, super-init-not-called
     def __init__(self, port, addr="127.0.0.1"):
         """Initialize the socket and initialize pdb."""
 

--- a/fspath/fspath.py
+++ b/fspath/fspath.py
@@ -3,7 +3,7 @@ u"""
 semantic path names and much more
 """
 
-# pylint: disable=invalid-name, bad-continuation
+# pylint: disable=invalid-name
 
 # ==============================================================================
 # imports
@@ -262,11 +262,10 @@ class FSPath(six.text_type):  # pylint: disable=too-many-public-methods
         """
         if os.sep == "/":
             return six.text_type(self)
-        else:
-            p = six.text_type(self)
-            if p[1] == ":":
-                p = "/" + p.replace(":", "", 1)
-            return p.replace(os.sep, "/")
+        p = six.text_type(self)
+        if p[1] == ":":
+            p = "/" + p.replace(":", "", 1)
+        return p.replace(os.sep, "/")
 
     @property
     def NTPATH(self):
@@ -520,7 +519,7 @@ class FSPath(six.text_type):  # pylint: disable=too-many-public-methods
         if system in ('FreeBSD', 'Darwin'):
             cmd = 'open'
 
-        from ._which import which
+        from ._which import which  # pylint: disable=import-outside-toplevel, cyclic-import
         cmd = which(cmd, findall=False)
         if cmd:
             os.system(cmd + " " + self)
@@ -696,7 +695,7 @@ def callEXE(cmd, *args, **kwargs):
        print("stderr: %s" % err)
        print("exit code = %d" % rc)
     """
-    from ._which import which
+    from ._which import which  # pylint: disable=import-outside-toplevel, cyclic-import
     exe = which(cmd, findall=False)
     if exe is None:
         raise IOError('command "%s" not availble!' % cmd)

--- a/fspath/main.py
+++ b/fspath/main.py
@@ -33,6 +33,7 @@ def _cli_find_file(cli):
         fspath find ".*\\.py$"  .
     """
     for match in cli.folder.reMatchFind(
+            # pylint: disable=superfluous-parens
             cli.regexpr, use_dirs=(not cli.nodirs), use_files=(not cli.nofiles)):
         cli.OUT.write(match + "\n")
 
@@ -55,7 +56,7 @@ def main():
     """
     cli = CLI(description=main.__doc__)
 
-    from .win import _cli_py2exe
+    from .win import _cli_py2exe  # pylint: disable=import-outside-toplevel
     py2exe = cli.addCMDParser(_cli_py2exe, cmdName='py2exe')
     py2exe.add_argument(
         "script"

--- a/fspath/progressbar.py
+++ b/fspath/progressbar.py
@@ -46,4 +46,3 @@ def progressbar(step, maxSteps, barSize=None, pipe=sys.stdout
     p_bar = fillchar * int(round(percent / 100 * barSize))
     pipe.write((prompt +  "[%s] %3.0f%%") % (p_bar.ljust(barSize, restchar), percent))
     pipe.flush()
-

--- a/fspath/progressbar.py
+++ b/fspath/progressbar.py
@@ -36,7 +36,9 @@ def progressbar(step, maxSteps, barSize=None, pipe=sys.stdout
     * barSize: char length of the progress-bar
     """
 
-    percent = float(100)/maxSteps*step
+    percent = 0
+    if step and maxSteps:
+        percent = float(100)/maxSteps*step
 
     prompt = "\r" + prompt
     if barSize is None:

--- a/fspath/sui.py
+++ b/fspath/sui.py
@@ -4,7 +4,7 @@ Simple user interface via terminal (win & \*nix)
 
 This module is in a very early stage, don't use it!
 """
-# pylint: disable=invalid-name, bad-continuation, wrong-import-position
+# pylint: disable=invalid-name, wrong-import-position
 
 # ==============================================================================
 # imports
@@ -52,8 +52,9 @@ class SimpleUserInterface(object):
             self.ui_out = cli.OUT
 
     if CONSOLE_TYPE == 'tty':
-        import tty     # pylint: disable=E0401
-        import termios # pylint: disable=E0401
+        # pylint: disable=import-outside-toplevel
+        import tty
+        import termios
         @classmethod
         def getchr(cls):
             "Get a single unicode character on Linux & Unix."
@@ -86,7 +87,7 @@ class SimpleUserInterface(object):
 
 
     elif CONSOLE_TYPE == 'cmd':
-        import msvcrt   # pylint: disable=E0401
+        import msvcrt   # pylint: disable=import-outside-toplevel
         @classmethod
         def getchr(cls):
             "Get a single unicode character on Windows."
@@ -280,7 +281,7 @@ class SimpleUserInterface(object):
             ch = cls.readkey()
             if ch == stop_char:
                 break
-            elif ch == KEY.BACKSPACE:
+            if ch == KEY.BACKSPACE:
                 if in_fspath:
                     in_fspath = in_fspath[:-1]
                     prompt(in_fspath)
@@ -419,7 +420,7 @@ class ASCIITableFormatter(object):
     def __init__(self, *cols):
         self.coldef = cols
 
-    def get_value(self, attr, row, default='?'):  # pylint: disable=no-self-use
+    def get_value(self, attr, row, default='?'):
         u"""get value from col (attr) and row"""
         val = default
         if hasattr(row, "__getitem__"):
@@ -428,7 +429,7 @@ class ASCIITableFormatter(object):
             val = getattr(row, attr, None)
         return val
 
-    def escape(self, value): # pylint: disable=no-self-use
+    def escape(self, value):
         u"""escape value"""
         return value
 

--- a/fspath/win.py
+++ b/fspath/win.py
@@ -7,7 +7,6 @@ Windows stuff
 import os
 import io
 import six
-from .fspath import FSPath
 
 # ==============================================================================
 def wrapScriptExe(script, shebang = u"#!python.exe"):
@@ -30,6 +29,8 @@ def wrapScriptExe(script, shebang = u"#!python.exe"):
 
     """
 
+    # pylint: disable=import-outside-toplevel
+    from .fspath import FSPath
     from pip._vendor.distlib.scripts import ScriptMaker
     from pip._vendor.distlib.compat import ZipFile
 

--- a/setup.py
+++ b/setup.py
@@ -2,24 +2,37 @@
 # pylint: disable=C
 
 import os
-from os.path import join as ospj
 import io
-import imp
 from setuptools import setup, find_packages
 
 _dir = os.path.abspath(os.path.dirname(__file__))
 
-#sys.path.append(_dir)
+SRC    = os.path.join(_dir, 'fspath')
+README = os.path.join(_dir, 'README.rst')
+DOCS   = os.path.join(_dir, 'docs')
+TESTS  = os.path.join(_dir, 'tests')
 
-SRC    = ospj(_dir, 'fspath')
-README = ospj(_dir, 'README.rst')
-DOCS   = ospj(_dir, 'docs')
-TESTS  = ospj(_dir, 'tests')
+try:
+    # Python 2.7
+    from imp import load_source
+except ImportError:
+    import importlib
+    def load_source(modname, modpath):
+        # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+        spec = importlib.util.spec_from_file_location(modname, modpath)
+        if not spec:
+            raise ValueError("Error loading '%s' module" % modpath)
+        module = importlib.util.module_from_spec(spec)
+        if not spec.loader:
+            raise ValueError("Error loading '%s' module" % modpath)
+        spec.loader.exec_module(module)
+        return module
 
 # import pkginfo without importing 'fspath/__init__.py' which imports
 # third-party dependencies that need to be installed first (e.g. 'six').
 
-PKG = imp.load_source('__pkginfo__', ospj(SRC, '__pkginfo__.py'))
+PKG = load_source('__pkginfo__', os.path.join(SRC, '__pkginfo__.py'))
+
 
 def readFile(fname, m='rt', enc='utf-8', nl=None):
     with io.open(fname, mode=m, encoding=enc, newline=nl) as f:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8; mode: python -*-
-# pylint: disable=invalid-name
+# pylint: disable=C
 
 import os
 from os.path import join as ospj

--- a/tests/test_FSPath.py
+++ b/tests/test_FSPath.py
@@ -17,8 +17,7 @@ def test_download():
         arch.delete()
     assert not arch.EXISTS
 
-    arch.download(url,
-                  chunksize=1024, ticker=True)
+    arch.download(url, chunksize=1024, ticker=True)
     assert arch.EXISTS
     assert arch.SIZE > MIN_FILESIZE
 
@@ -38,4 +37,3 @@ def test_makedirs():
         foo.delete()
     assert foo.makedirs()
     assert not foo.makedirs()
-    

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, pylint
+env_list = pylint, py{27,38,39,310,311}
 
 [testenv]
 # passenv = HOME


### PR DESCRIPTION
Related: https://github.com/python/cpython/issues/98040
Closes: https://github.com/return42/fspath/issues/3

